### PR TITLE
Lh/extension refactor

### DIFF
--- a/src/SparseVariables.jl
+++ b/src/SparseVariables.jl
@@ -20,7 +20,6 @@ export @sparsevariable
 export insertvar!
 export unsafe_insertvar!
 export table
-export nnz
 
 function __init__()
     @require DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0" include(

--- a/src/SparseVariables.jl
+++ b/src/SparseVariables.jl
@@ -20,6 +20,7 @@ export @sparsevariable
 export insertvar!
 export unsafe_insertvar!
 export table
+export nnz
 
 function __init__()
     @require DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0" include(

--- a/src/indexedarray.jl
+++ b/src/indexedarray.jl
@@ -264,9 +264,9 @@ end
 # Extension for standard JuMP macros
 function Containers.container(
     f::Function,
-    names,
     indices,
     D::Type{IndexedVarArray},
+    names,
 )
     iva_names = NamedTuple{tuple(names...)}(indices.prod.iterators)
     T = Tuple{eltype.(indices.prod.iterators)...}
@@ -282,5 +282,5 @@ end
 # Fallback when no names are provided
 function Containers.container(f::Function, indices, D::Type{IndexedVarArray})
     index_vars = Symbol.("i$i" for i in 1:length(indices.prod.iterators))
-    return Containers.container(f, index_vars, indices, D)
+    return Containers.container(f, indices, D, index_vars)
 end

--- a/src/indexedarray.jl
+++ b/src/indexedarray.jl
@@ -252,20 +252,18 @@ function _getcache(sa::IndexedVarArray{N,T}, pat::P) where {N,T,P}
     return sa.index_cache[t]
 end
 
-
-
 function _from_linear(i, d)
     r = Int[]
     for dx in d
         push!(r, mod1(i, dx))
-        i = div(i+dx-1, dx)
+        i = div(i + dx - 1, dx)
     end
     return tuple(r...)
 end
 
 function _linear_lookup(sa::IndexedVarArray, i::Integer)
     active = _from_linear(i, [length(i) for i in sa.index_names])
-    [sa.index_names[i][active[i]] for i in 1:length(active)]
+    return [sa.index_names[i][active[i]] for i in 1:length(active)]
 end
 
 # Size and length over full range (as for SparseArray)
@@ -273,4 +271,6 @@ Base.size(A::IndexedVarArray) = tuple([length(i) for i in A.index_names]...)
 Base.length(sa::IndexedVarArray) = prod(size(sa))
 
 # Linear lookup (not sure how useful this is, but mandated by interface for AbstractArray)
-Base.getindex(sa::IndexedVarArray{N,T}, i::Integer) where {N,T} =  Base.getindex(sa, _linear_lookup(sa, i)...)
+function Base.getindex(sa::IndexedVarArray{N,T}, i::Integer) where {N,T}
+    return Base.getindex(sa, _linear_lookup(sa, i)...)
+end

--- a/src/indexedarray.jl
+++ b/src/indexedarray.jl
@@ -237,29 +237,7 @@ function _getcache(sa::IndexedVarArray{N,T}, pat::P) where {N,T,P}
     return sa.index_cache[t]
 end
 
-function _from_linear(i, d)
-    r = Int[]
-    for dx in d
-        push!(r, mod1(i, dx))
-        i = div(i + dx - 1, dx)
-    end
-    return tuple(r...)
-end
-
-function _linear_lookup(sa::IndexedVarArray, i::Integer)
-    active = _from_linear(i, [length(ixn) for ixn in sa.index_names])
-    return [sa.index_names[ix][iv] for (ix, iv) in pairs(active)]
-end
-
-# Size and length over full range (as for SparseArray)
-Base.size(A::IndexedVarArray) = tuple([length(i) for i in A.index_names]...)
-Base.length(sa::IndexedVarArray) = prod(size(sa))
-nnz(sa::IndexedVarArray) = length(_data(sa))
-
-# Linear lookup (not sure how useful this is, but mandated by interface for AbstractArray)
-function Base.getindex(sa::IndexedVarArray{N,T}, i::Integer) where {N,T}
-    return Base.getindex(sa, _linear_lookup(sa, i)...)
-end
+Base.length(sa::IndexedVarArray) = length(_data(sa))
 
 # Extension for standard JuMP macros
 function Containers.container(

--- a/src/indexedarray.jl
+++ b/src/indexedarray.jl
@@ -269,6 +269,7 @@ end
 # Size and length over full range (as for SparseArray)
 Base.size(A::IndexedVarArray) = tuple([length(i) for i in A.index_names]...)
 Base.length(sa::IndexedVarArray) = prod(size(sa))
+nnz(sa::IndexedVarArray) = length(_data(sa))
 
 # Linear lookup (not sure how useful this is, but mandated by interface for AbstractArray)
 function Base.getindex(sa::IndexedVarArray{N,T}, i::Integer) where {N,T}

--- a/src/indexedarray.jl
+++ b/src/indexedarray.jl
@@ -237,7 +237,6 @@ function _getcache(sa::IndexedVarArray{N,T}, pat::P) where {N,T,P}
     return sa.index_cache[t]
 end
 
-Base.length(sa::IndexedVarArray) = length(_data(sa))
 
 # Extension for standard JuMP macros
 function Containers.container(

--- a/src/indexedarray.jl
+++ b/src/indexedarray.jl
@@ -4,8 +4,7 @@
     Structure for holding an optimization variable with a sparse structure with extra indexing
 """
 struct IndexedVarArray{N,T} <: AbstractSparseArray{VariableRef,N}
-    model::Model
-    name::Any
+    f::Function
     data::Dictionary{T,VariableRef}
     index_names::NamedTuple
     index_cache::Vector{Dictionary}
@@ -22,8 +21,7 @@ function IndexedVarArray(
     N = length(fieldtypes(Ts))
     dict = Dictionary{T,VariableRef}()
     return model[Symbol(name)] = IndexedVarArray{N,T}(
-        model,
-        name,
+        (ix...) -> createvar(model, name, ix; lower_bound, kw_args...),
         dict,
         index_names,
         Vector{Dictionary}(undef, 2^N),
@@ -46,8 +44,7 @@ function IndexedVarArray(
         (createvar(model, name, k; lower_bound, kw_args...) for k in indices),
     )
     return model[Symbol(name)] = IndexedVarArray{N,T}(
-        model,
-        name,
+        (ix...) -> createvar(model, name, ix; lower_bound, kw_args...),
         dict,
         index_names,
         Vector{Dictionary}(undef, 2^N),
@@ -109,7 +106,7 @@ function insertvar!(
     !valid_index(var, index) && throw(BoundsError(var, index))# "Not a valid index for $(var.name): $index"g
     already_defined(var, index) && error("$(var.name): $index already defined")
 
-    var[index] = createvar(var.model, var.name, index; lower_bound, kw_args...)
+    var[index] = var.f(index...)
 
     clear_cache!(var)
     return var[index]
@@ -127,19 +124,7 @@ function unsafe_insertvar!(
     lower_bound = 0,
     kw_args...,
 ) where {N,T}
-    return var[index] =
-        createvar(var.model, var.name, index; lower_bound, kw_args...)
-
-    #TODO: Reactivate this later
-    # If active caches, update with new variable
-    # cache = _getcache(var.sa, index)
-    # for ind in keys(cache)
-    #     vred = Tuple(val for (i, val) in enumerate(index) if i in ind)
-    #     if !(vred in keys(var.index_cache[ind]))
-    #         var.index_cache[ind][vred] = []
-    #     end
-    #     push!(var.index_cache[ind][vred], index)
-    # end
+    return var[index] = var.f(index...)
 end
 
 joinex(ex1, ex2) = :($ex1..., $ex2...)
@@ -274,4 +259,28 @@ nnz(sa::IndexedVarArray) = length(_data(sa))
 # Linear lookup (not sure how useful this is, but mandated by interface for AbstractArray)
 function Base.getindex(sa::IndexedVarArray{N,T}, i::Integer) where {N,T}
     return Base.getindex(sa, _linear_lookup(sa, i)...)
+end
+
+# Extension for standard JuMP macros
+function Containers.container(
+    f::Function,
+    names,
+    indices,
+    D::Type{IndexedVarArray},
+)
+    iva_names = NamedTuple{tuple(names...)}(indices.prod.iterators)
+    T = Tuple{eltype.(indices.prod.iterators)...}
+    N = length(names)
+    return IndexedVarArray{N,T}(
+        f,
+        Dictionary{T,VariableRef}(),
+        iva_names,
+        Vector{Dictionary}(undef, 2^N),
+    )
+end
+
+# Fallback when no names are provided
+function Containers.container(f::Function, indices, D::Type{IndexedVarArray})
+    index_vars = Symbol.("i$i" for i in 1:length(indices.prod.iterators))
+    return Containers.container(f, index_vars, indices, D)
 end

--- a/src/indexedarray.jl
+++ b/src/indexedarray.jl
@@ -251,3 +251,26 @@ function _getcache(sa::IndexedVarArray{N,T}, pat::P) where {N,T,P}
     end
     return sa.index_cache[t]
 end
+
+
+
+function _from_linear(i, d)
+    r = Int[]
+    for dx in d
+        push!(r, mod1(i, dx))
+        i = div(i+dx-1, dx)
+    end
+    return tuple(r...)
+end
+
+function _linear_lookup(sa::IndexedVarArray, i::Integer)
+    active = _from_linear(i, [length(i) for i in sa.index_names])
+    [sa.index_names[i][active[i]] for i in 1:length(active)]
+end
+
+# Size and length over full range (as for SparseArray)
+Base.size(A::IndexedVarArray) = tuple([length(i) for i in A.index_names]...)
+Base.length(sa::IndexedVarArray) = prod(size(sa))
+
+# Linear lookup (not sure how useful this is, but mandated by interface for AbstractArray)
+Base.getindex(sa::IndexedVarArray{N,T}, i::Integer) where {N,T} =  Base.getindex(sa, _linear_lookup(sa, i)...)

--- a/src/indexedarray.jl
+++ b/src/indexedarray.jl
@@ -247,8 +247,8 @@ function _from_linear(i, d)
 end
 
 function _linear_lookup(sa::IndexedVarArray, i::Integer)
-    active = _from_linear(i, [length(i) for i in sa.index_names])
-    return [sa.index_names[i][active[i]] for i in 1:length(active)]
+    active = _from_linear(i, [length(ixn) for ixn in sa.index_names])
+    return [sa.index_names[ix][iv] for (ix, iv) in pairs(active)]
 end
 
 # Size and length over full range (as for SparseArray)

--- a/src/indexedarray.jl
+++ b/src/indexedarray.jl
@@ -237,7 +237,6 @@ function _getcache(sa::IndexedVarArray{N,T}, pat::P) where {N,T,P}
     return sa.index_cache[t]
 end
 
-
 # Extension for standard JuMP macros
 function Containers.container(
     f::Function,

--- a/src/sparsearray.jl
+++ b/src/sparsearray.jl
@@ -38,7 +38,7 @@ Base.size(sa::AbstractSparseArray) = length(_data(sa))
 Base.keys(sa::AbstractSparseArray) = keys(_data(sa))
 
 function Base.summary(io::IO, sa::AbstractSparseArray)
-    num_entries = length(sa)
+    num_entries = nnz(sa)
     return print(
         io,
         typeof(sa),

--- a/src/sparsearray.jl
+++ b/src/sparsearray.jl
@@ -16,7 +16,7 @@ function Base.getindex(
 end
 
 function Base.getindex(sa::AbstractSparseArray{T,N}, idx...) where {T,N}
-    length(idx) != 1 && length(idx) != N && throw(BoundsError(sa, idx))
+    length(idx) != N && throw(BoundsError(sa, idx))
     return _getindex(sa, idx)
 end
 
@@ -46,6 +46,7 @@ function Base.summary(io::IO, sa::AbstractSparseArray)
     )
 end
 Base.length(sa::AbstractSparseArray) = length(_data(sa))
+
 
 function Base.show(io::IO, ::MIME"text/plain", sa::AbstractSparseArray)
     summary(io, sa)

--- a/src/sparsearray.jl
+++ b/src/sparsearray.jl
@@ -99,8 +99,6 @@ function SparseArray(d::Dict{K,T}) where {T,N,K<:NTuple{N,Any}}
     return SparseArray(Dictionary(d))
 end
 
-
-
 function SparseArray(d::Dict{S,T}) where {S,T}
     dd = Dict((key,) => val for (key, val) in d)
     return SparseArray(Dictionary(dd))

--- a/src/sparsearray.jl
+++ b/src/sparsearray.jl
@@ -33,12 +33,10 @@ function Base.setindex!(sa::AbstractSparseArray{T,N}, val, idx...) where {T,N}
     return setindex!(sa, val, idx)
 end
 
-nnz(sa::AbstractSparseArray) = length(_data(sa))
-Base.size(sa::AbstractSparseArray) = length(_data(sa))
 Base.keys(sa::AbstractSparseArray) = keys(_data(sa))
 
 function Base.summary(io::IO, sa::AbstractSparseArray)
-    num_entries = nnz(sa)
+    num_entries = length(sa)
     return print(
         io,
         typeof(sa),
@@ -47,6 +45,8 @@ function Base.summary(io::IO, sa::AbstractSparseArray)
         isone(num_entries) ? " entry" : " entries",
     )
 end
+Base.length(sa::AbstractSparseArray) = length(_data(sa))
+
 function Base.show(io::IO, ::MIME"text/plain", sa::AbstractSparseArray)
     summary(io, sa)
     if !iszero(length(_data(sa)))

--- a/src/sparsearray.jl
+++ b/src/sparsearray.jl
@@ -46,7 +46,7 @@ function Base.summary(io::IO, sa::AbstractSparseArray)
     )
 end
 Base.length(sa::AbstractSparseArray) = length(_data(sa))
-
+Base.sum(sa::AbstractSparseArray) = sum(_data(sa))
 
 function Base.show(io::IO, ::MIME"text/plain", sa::AbstractSparseArray)
     summary(io, sa)

--- a/src/sparsearray.jl
+++ b/src/sparsearray.jl
@@ -33,7 +33,7 @@ function Base.setindex!(sa::AbstractSparseArray{T,N}, val, idx...) where {T,N}
     return setindex!(sa, val, idx)
 end
 
-Base.length(sa::AbstractSparseArray) = length(_data(sa))
+nnz(sa::AbstractSparseArray) = length(_data(sa))
 Base.size(sa::AbstractSparseArray) = length(_data(sa))
 Base.keys(sa::AbstractSparseArray) = keys(_data(sa))
 

--- a/src/sparsearray.jl
+++ b/src/sparsearray.jl
@@ -16,7 +16,7 @@ function Base.getindex(
 end
 
 function Base.getindex(sa::AbstractSparseArray{T,N}, idx...) where {T,N}
-    length(idx) != N && throw(BoundsError(sa, idx))
+    length(idx) != 1 && length(idx) != N && throw(BoundsError(sa, idx))
     return _getindex(sa, idx)
 end
 
@@ -98,6 +98,8 @@ end
 function SparseArray(d::Dict{K,T}) where {T,N,K<:NTuple{N,Any}}
     return SparseArray(Dictionary(d))
 end
+
+
 
 function SparseArray(d::Dict{S,T}) where {S,T}
     dd = Dict((key,) => val for (key, val) in d)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -231,12 +231,12 @@ end
         (cars = cars, year = year),
         collect(keys(car_cost)),
     )
-    @test length(y) == length(car_cost)
+    @test nnz(y) == length(car_cost)
     z = IndexedVarArray(m, "z", (cars = cars, year = year))
     for (cr, yr) in keys(car_cost)
         insertvar!(z, cr, yr)
     end
-    @test length(z) == length(car_cost)
+    @test nnz(z) == length(car_cost)
     # Add invalid set of values
     for (cr, yr) in keys(car_cost)
         # All should fail, either already added, or invalid keys
@@ -244,7 +244,7 @@ end
     end
     @test_throws BoundsError insertvar!(z, "lotus", 2001)
     @test_throws BoundsError insertvar!(z, "bmw", 1957)
-    @test length(z) == length(y)
+    @test nnz(z) == nnz(y)
 
     # Slicing and lookup
     @test length(y[:, 2001]) == 2
@@ -254,11 +254,11 @@ end
 
     # Unsafe also works
     unsafe_insertvar!(z, "lotus", 1957)
-    @test length(z) == 5
+    @test nnz(z) == 5
 
     # Alternative constructor
     z2 = IndexedVarArray(m, "z2", (cars = cars, year = year), keys(car_cost))
-    @test length(z2) == length(car_cost)
+    @test nnz(z2) == length(car_cost)
 
     # Larger number of variables (to test caching)
     N = 2000

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -300,10 +300,8 @@ end
     @test length(z3.index_cache[4]) == 0
 end
 
-
-
 @testset "Array Interface" begin
-    for d in [(3,5,7), (2,3), (3,4), (2,5,3,4)]
+    for d in [(3, 5, 7), (2, 3), (3, 4), (2, 5, 3, 4)]
         idx = reshape(collect(1:prod(d)), d)
         for i in 1:prod(d)
             @test idx[SparseVariables._from_linear(i, d)...] == idx[i]
@@ -312,7 +310,7 @@ end
 
     # Test linear indexing
     m = Model()
-    x = IndexedVarArray(m, "x", (i=1:3,j=1:4,k=1:3))
+    x = IndexedVarArray(m, "x", (i = 1:3, j = 1:4, k = 1:3))
     insertvar!(x, 1, 1, 1)
     @test x[1] === x[1, 1, 1]
     insertvar!(x, 2, 1, 1)
@@ -321,11 +319,8 @@ end
     @test x[21] === x[3, 3, 2]
 
     # Test size
-    for I=1:5, J=1:5, K=1:5
-        x = IndexedVarArray(m, "x", (i=1:I,j=1:J,k=1:K))
+    for I in 1:5, J in 1:5, K in 1:5
+        x = IndexedVarArray(m, "x", (i = 1:I, j = 1:J, k = 1:K))
         @test size(x) == (I, J, K)
     end
-
-
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -301,7 +301,7 @@ end
 end
 
 @testset "JuMP extension" begin
-    
+
     # Test JuMP Extension
     m = Model()
     @variable(m, x[i = 1:3, j = 100:102] >= 0, container = IndexedVarArray)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -323,4 +323,14 @@ end
         x = IndexedVarArray(m, "x", (i = 1:I, j = 1:J, k = 1:K))
         @test size(x) == (I, J, K)
     end
+
+    # Test JuMP Extension
+    m = Model()
+    @variable(m, x[i = 1:3, j = 100:102] >= 0, container = IndexedVarArray)
+    @test nnz(x) == 0
+    @test length(x) == 9
+    insertvar!(x, 1, 100)
+    @test nnz(x) == 1
+    unsafe_insertvar!(x, 2, 102)
+    @test nnz(x) == 2
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -231,12 +231,12 @@ end
         (cars = cars, year = year),
         collect(keys(car_cost)),
     )
-    @test nnz(y) == length(car_cost)
+    @test length(y) == length(car_cost)
     z = IndexedVarArray(m, "z", (cars = cars, year = year))
     for (cr, yr) in keys(car_cost)
         insertvar!(z, cr, yr)
     end
-    @test nnz(z) == length(car_cost)
+    @test length(z) == length(car_cost)
     # Add invalid set of values
     for (cr, yr) in keys(car_cost)
         # All should fail, either already added, or invalid keys
@@ -244,7 +244,7 @@ end
     end
     @test_throws BoundsError insertvar!(z, "lotus", 2001)
     @test_throws BoundsError insertvar!(z, "bmw", 1957)
-    @test nnz(z) == nnz(y)
+    @test length(z) == length(y)
 
     # Slicing and lookup
     @test length(y[:, 2001]) == 2
@@ -254,11 +254,11 @@ end
 
     # Unsafe also works
     unsafe_insertvar!(z, "lotus", 1957)
-    @test nnz(z) == 5
+    @test length(z) == 5
 
     # Alternative constructor
     z2 = IndexedVarArray(m, "z2", (cars = cars, year = year), keys(car_cost))
-    @test nnz(z2) == length(car_cost)
+    @test length(z2) == length(car_cost)
 
     # Larger number of variables (to test caching)
     N = 2000
@@ -300,37 +300,14 @@ end
     @test length(z3.index_cache[4]) == 0
 end
 
-@testset "Array Interface" begin
-    for d in [(3, 5, 7), (2, 3), (3, 4), (2, 5, 3, 4)]
-        idx = reshape(collect(1:prod(d)), d)
-        for i in 1:prod(d)
-            @test idx[SparseVariables._from_linear(i, d)...] == idx[i]
-        end
-    end
-
-    # Test linear indexing
-    m = Model()
-    x = IndexedVarArray(m, "x", (i = 1:3, j = 1:4, k = 1:3))
-    insertvar!(x, 1, 1, 1)
-    @test x[1] === x[1, 1, 1]
-    insertvar!(x, 2, 1, 1)
-    @test x[2] === x[2, 1, 1]
-    insertvar!(x, 3, 3, 2)
-    @test x[21] === x[3, 3, 2]
-
-    # Test size
-    for I in 1:5, J in 1:5, K in 1:5
-        x = IndexedVarArray(m, "x", (i = 1:I, j = 1:J, k = 1:K))
-        @test size(x) == (I, J, K)
-    end
-
+@testset "JuMP extension" begin
+    
     # Test JuMP Extension
     m = Model()
     @variable(m, x[i = 1:3, j = 100:102] >= 0, container = IndexedVarArray)
-    @test nnz(x) == 0
-    @test length(x) == 9
+    @test length(x) == 0
     insertvar!(x, 1, 100)
-    @test nnz(x) == 1
+    @test length(x) == 1
     unsafe_insertvar!(x, 2, 102)
-    @test nnz(x) == 2
+    @test length(x) == 2
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -299,3 +299,33 @@ end
     SparseVariables.clear_cache!(z3)
     @test length(z3.index_cache[4]) == 0
 end
+
+
+
+@testset "Array Interface" begin
+    for d in [(3,5,7), (2,3), (3,4), (2,5,3,4)]
+        idx = reshape(collect(1:prod(d)), d)
+        for i in 1:prod(d)
+            @test idx[SparseVariables._from_linear(i, d)...] == idx[i]
+        end
+    end
+
+    # Test linear indexing
+    m = Model()
+    x = IndexedVarArray(m, "x", (i=1:3,j=1:4,k=1:3))
+    insertvar!(x, 1, 1, 1)
+    @test x[1] === x[1, 1, 1]
+    insertvar!(x, 2, 1, 1)
+    @test x[2] === x[2, 1, 1]
+    insertvar!(x, 3, 3, 2)
+    @test x[21] === x[3, 3, 2]
+
+    # Test size
+    for I=1:5, J=1:5, K=1:5
+        x = IndexedVarArray(m, "x", (i=1:I,j=1:J,k=1:K))
+        @test size(x) == (I, J, K)
+    end
+
+
+
+end


### PR DESCRIPTION
Support extending standards JuMP macros (#19):

```
m = Model()
@variable(m, x[i = 1:3, j = 100:102] >= 0, container = IndexedVarArray)
```
Should also fix #22 for `IndexedVarArray`

This PR includes changes from PR #24, can separate later if we don't want those changes, but is using e.g. `nnz` here.