### PR TITLE
Test fast initialization of IndexedVarArray

### DIFF
--- a/src/indexedarray.jl
+++ b/src/indexedarray.jl
@@ -3,11 +3,12 @@
 
     Structure for holding an optimization variable with a sparse structure with extra indexing
 """
-struct IndexedVarArray{V<:AbstractVariableRef,N,T} <: AbstractSparseArray{V,N}
-    f::Function
+mutable struct IndexedVarArray{V<:AbstractVariableRef,N,T} <:
+               AbstractSparseArray{V,N}
+    const f::Function
     data::Dictionary{T,V}
-    index_names::NamedTuple
-    index_cache::Vector{Dictionary}
+    const index_names::NamedTuple
+    const index_cache::Vector{Dictionary}
 end
 
 _data(sa::IndexedVarArray) = sa.data
@@ -54,6 +55,28 @@ Insert a new variable with the given index withouth checking if the index is val
 """
 function unsafe_insertvar!(var::IndexedVarArray{V,N,T}, index...) where {V,N,T}
     return var[index] = var.f(index...)
+end
+
+"""
+    unsafe_initializevars!(var::IndexedVarArray{V,N,T}, indices)
+
+Initialize a variable `var` with all `indices` at once without checking for valid indices or 
+    if it already has data for maximum performance.
+"""
+function unsafe_initializevars!(
+    var::IndexedVarArray{V,N,T},
+    indices,
+) where {V,N,T}
+    var.data = Dictionary(indices, (var.f(i...) for i in indices))
+    return var
+end
+
+function unsafe_initializevars_alt!(
+    var::IndexedVarArray{V,N,T},
+    indices,
+) where {V,N,T}
+    merge!(var.data, Dictionary(indices, (var.f(i...) for i in indices)))
+    return var
 end
 
 joinex(ex1, ex2) = :($ex1..., $ex2...)


### PR DESCRIPTION
It would be nice to have faster initialization in cases where we know the nzs. Not quite happy with this solution:
- [ ] would prefer to use immutable structs
- [ ] better suggestion for API
- [ ]  possible to integrate with macros?

```julia
using SparseVariables, JuMP
using BenchmarkTools

sparse_keys(N) = unique((rand(1:N), rand(1:N), rand(1:N)) for _ in 1:N)
N = 100_000
D = sparse_keys(N)

function test1(N, D) # Replace data
    model = Model()
    @variable(model, x[i = 1:N, j = 1:N, k = 1:N], container = IndexedVarArray)
    SparseVariables.unsafe_initializevars!(x, D)
    return x
end

function test2(N, D) # Insert iteratively
    model = Model()
    @variable(model, x[i = 1:N, j = 1:N, k = 1:N], container = IndexedVarArray)
    @inbounds for d in D
        SparseVariables.unsafe_insertvar!(x, d...)
    end
    return x
end

function test3(N, D) # Update data with from new Dictionary
    model = Model()
    @variable(model, x[i = 1:N, j = 1:N, k = 1:N], container = IndexedVarArray)
    SparseVariables.unsafe_initializevars_alt!(x, D)
    return x
end
```

```julia-repl
julia> @btime test1(N,D);
  48.202 ms (1398734 allocations: 62.89 MiB)

julia> @btime test2(N,D);
  75.165 ms (1598754 allocations: 78.49 MiB)

julia> @btime test3(N,D);
  60.305 ms (1398770 allocations: 76.68 MiB)
```

