### PR TITLE
Migrate from SnoopPrecompile to PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,10 @@ version = "0.7.1"
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 Dictionaries = "0.3"
 JuMP = "1.4.0"
-SnoopPrecompile = "1"
+PrecompileTools = "1"
 julia = "1.6"

--- a/src/SparseVariables.jl
+++ b/src/SparseVariables.jl
@@ -3,7 +3,7 @@ module SparseVariables
 using Dictionaries
 using JuMP
 using LinearAlgebra
-using SnoopPrecompile
+using PrecompileTools
 
 include("sparsearray.jl")
 include("dictionaries.jl")
@@ -15,7 +15,7 @@ export IndexedVarArray
 export insertvar!
 export unsafe_insertvar!
 
-@precompile_setup begin
+@setup_workload begin
     # Putting some things in `setup` can reduce the size of the
     # precompile file and potentially make loading faster.
     rs = 1:10
@@ -24,7 +24,7 @@ export unsafe_insertvar!
     sys = [:a, :b]
     m = Model()
 
-    @precompile_all_calls begin
+    @compile_workload begin
         # all calls in this block will be precompiled, regardless of whether
         # they belong to your package or not (on Julia 1.8 and higher)
 


### PR DESCRIPTION
This pull request migrates the package from [SnoopPrecompile](https://github.com/timholy/SnoopCompile.jl/tree/master/SnoopPrecompile) to [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl).
PrecompileTools is **nearly a drop-in replacement** except that there are **changes in naming and how developers locally disable precompilation** (to make their development workflow more efficient). These changes are described in [PrecompileTool's enhanced documentation](https://julialang.github.io/PrecompileTools.jl/stable/), which also includes instructions for users on how to set up custom "Startup" packages, handling precompilation tasks that are not amenable to workloads, and tips for troubleshooting.

Why the new package? It meets several goals:

- The name "SnoopPrecompile" was easily confused with "SnoopCompile," a package designed for *analyzing* rather than *enacting* precompilation.
- SnoopPrecompile/PrecompileTools has become (directly or indirectly) a dependency for much of the Julia ecosystem, a trend that seems likely to grow with time. It makes sense to host it in a more central location than one developer's personal account.
- As Julia's own stdlibs migrate to become independently updateable (true for DelimitedFiles in Julia 1.9, with others anticipated for Julia 1.10), several of them would like to use PrecompileTools for high-quality precompilation. That requires making PrecompileTools its own "upgradable stdlib."
- We wanted to change the [use of Preferences](https://github.com/timholy/SnoopCompile.jl/issues/356) to make packages more independent of one another. Since this would have been a breaking change, it seemed like a good opportunity to fix other issues, too.

For more information and discussion, see this [discourse post](https://discourse.julialang.org/t/ann-snoopprecompile-precompiletools/97882).
