### PR TITLE
Add TranslateVarArray for simplified indexing

### DIFF
--- a/src/SparseVariables.jl
+++ b/src/SparseVariables.jl
@@ -10,6 +10,8 @@ include("dictionaries.jl")
 include("indexedarray.jl")
 include("tables.jl")
 
+include("translate.jl")
+
 export SparseArray
 export IndexedVarArray
 export insertvar!

--- a/src/translate.jl
+++ b/src/translate.jl
@@ -1,0 +1,122 @@
+"""
+    TranslateVarArray{V,N,T}
+
+    Structure for holding an optimization variable with a sparse structure with extra indexing
+    Translate from abstract types to type stable id for performance in dictionaries
+"""
+struct TranslateVarArray{V<:AbstractVariableRef,N,T} <: AbstractSparseArray{V,N}
+    f::Function
+    data::Dictionary{T,V}
+    index_names::NamedTuple
+    index_cache::Vector{Dictionary}
+end
+
+"""
+    translate
+    Function to translate from type instance to type stable (e.g. Int or String) for performance in dictionaries.
+    Extend this for types (e.g. Node or Link types) to improve performance
+"""
+function translate(x)
+    return x
+end
+function translate(::Type{T}) where {T}
+    return T
+end
+
+_data(sa::TranslateVarArray) = sa.data
+
+"""
+    insertvar!(var::IndexedVarArray{V,N,T}, index...)
+
+Insert a new variable with the given index only after checking if keys are valid and not already defined.
+"""
+function insertvar!(var::TranslateVarArray{V,N,T}, index...) where {V,N,T}
+    return insertvar!(var, SafeInsert(), index...)
+end
+function insertvar!(
+    var::TranslateVarArray{V,N,T},
+    ::SafeInsert = SafeInsert(),
+    index...,
+) where {V,N,T}
+    tindex = translate.(index)
+    !valid_index(var, index) && throw(BoundsError(var, index))# "Not a valid index for $(var.name): $index"g
+    already_defined(var, tindex) && error("$index already defined for array")
+    var[tindex] = var.f(tindex...)
+    clear_cache!(var)
+    return var[tindex]
+end
+
+# Extension for standard JuMP macros
+function Containers.container(
+    f::Function,
+    indices,
+    D::Type{TranslateVarArray},
+    names,
+)
+    iva_names = NamedTuple{tuple(names...)}(indices.prod.iterators)
+    T = Tuple{translate.(eltype.(indices.prod.iterators))...}
+    N = length(names)
+    V = first(Base.return_types(f))
+    return TranslateVarArray{V,N,T}(
+        f,
+        Dictionary{T,V}(),
+        iva_names,
+        Vector{Dictionary}(undef, 2^N),
+    )
+end
+
+@generated function _getindex(
+    sa::TranslateVarArray{T,N},
+    tpl::Tuple,
+) where {T,N}
+    lookup = true
+    slice = true
+    for t in fieldtypes(tpl)
+        if !isfixed(t)
+            lookup = false
+            if !iscolon(t)
+                slice = false
+            end
+        end
+    end
+
+    if lookup
+        return :(get(_data(sa), translate.(tpl), zero(T)))
+    elseif !slice
+        return :(retval = select(_data(sa), translate.(tpl));
+        length(retval) > 0 ? retval : zero(T))
+    else    # Return selection or zero if empty to avoid reduction of empty iterate
+        return :(retval = _select_var(sa, translate.(tpl));
+        length(retval) > 0 ? retval : zero(T))
+    end
+end
+
+function Base.firstindex(sa::TranslateVarArray, d)
+    return first(sort(sa.index_names[d]))
+end
+function Base.lastindex(sa::TranslateVarArray, d)
+    return last(sort(sa.index_names[d]))
+end
+
+function build_cache!(cache, pat, sa::TranslateVarArray{V,N,T}) where {V,N,T}
+    if isempty(cache)
+        for v in keys(sa)
+            vred = _active(v, translate.(pat))
+            nv = get!(cache, vred, T[])
+            push!(nv, v)
+        end
+    end
+    return cache
+end
+
+function _select_cached(sa::TranslateVarArray{V,N,T}, pat) where {V,N,T}
+    # TODO: Benchmark to find good cutoff-value for caching
+    # TODO: Return same type for type stability
+    tpat = translate.(pat)
+    length(_data(sa)) < 100 && return _select_gen(keys(_data(sa)), tpat)
+    cache =
+        _getcache(sa, tpat)::Dictionary{_decode_nonslices(sa, tpat),Vector{T}}
+    build_cache!(cache, tpat, sa)
+    vals = _dropslices_gen(tpat)
+    return get!(cache, vals, T[])
+end


### PR DESCRIPTION
There is a considerable overhead when indexing on custom types. This PR investigates if we can relatively easily translate to a simpler and type stable value for indexing under the hood:

```julia
using BenchmarkTools
using SparseVariables

const SV = SparseVariables

# Demo custom types
abstract type Node end
struct Source <: Node
    id::Int
end
struct Sink <: Node
    id::Int
end

# Translation to type-stable index
SV.translate(n::Node) = n.id
SV.translate(::Type{<:Node}) = Int

"""
    Indexing on custom types with `IndexedVarArray`
"""
function test(N)
    m = Model()
    @variable(
        m,
        x[i = SinkNode.(1:N), y = SourceNode.(1:N)],
        container = SV.IndexedVarArray
    )
    for i in SinkNode.(1:N), j in SourceNode.(1:N)
        insertvar!(x, i, j)
    end
end

"""
    Indexing on `Int` manually for performance with `IndexedVarArray`
"""
function test_ix(N)
    m = Model()
    @variable(m, x[i = 1:N, j = 1:N], container = SV.IndexedVarArray)
    for i = 1:N, j = 1:N
        insertvar!(x, i, j)
    end
end

"""
    Automatic translation to `Int` by `TranslateVarArray`
"""
function test_t(N)
    m = Model()
    @variable(
        m,
        x[i = SinkNode.(1:N), j = SourceNode.(1:N)],
        container = SV.TranslateVarArray
    )
    for i in SinkNode.(1:N), j in SourceNode.(1:N)
        insertvar!(x, i, j)
    end
end

"""
    Manual indexing by `Int` with `TranslateVarArray` for comparison
"""
function test_i(N)
    m = Model()
    @variable(m, x[i = 1:N, j = 1:N], container = SV.TranslateVarArray)
    for i = 1:N, j = 1:N
        insertvar!(x, i, j)
    end
end


N = 100
@info "Custom type w/IndexedVarArray"
@btime test(N)

@info "Manual Int w/IndexedVarArray"
@btime test_ix(N)

@info "Automatic w/TranslateVarArray"
@btime test_t(N)

@info "Manual Int w/TranslateVarArray"
@btime test_i(N)
```

```julia-repl
julia> include("translate_benchmark.jl")
[ Info: Custom type w/IndexedVarArray
  26.356 ms (460328 allocations: 20.33 MiB)
[ Info: Manual Int w/IndexedVarArray
  7.232 ms (200227 allocations: 11.38 MiB)
[ Info: Automatic w/TranslateVarArray
  13.335 ms (290328 allocations: 13.60 MiB)
[ Info: Manual Int w/TranslateVarArray
  9.945 ms (230227 allocations: 12.29 MiB)

```